### PR TITLE
Add `ParseExceptionResult` marker in `DefaultVisit()`

### DIFF
--- a/Rewrite/src/Rewrite.CSharp/CSharpParser.cs
+++ b/Rewrite/src/Rewrite.CSharp/CSharpParser.cs
@@ -78,7 +78,7 @@ public class CSharpParser : Core.Parser
                     .AddSyntaxTrees(syntaxTree);
                 var semanticModel = compilation.GetSemanticModel(syntaxTree);
 
-                var visitor = new CSharpParserVisitor(semanticModel);
+                var visitor = new CSharpParserVisitor(this, semanticModel);
                 cs = visitor.Visit(root) as Cs.CompilationUnit ?? throw new InvalidOperationException("Visitor.Visit returned null instead of Compilation Unit");
             }
             catch (Exception t)


### PR DESCRIPTION
By adding this marker we can use the `FindParseFailures` recipe to produce reports, where we get a corresponding entry for each `J.Unknown` with that marker, including relevant details.
