### PR TITLE
Fix mapping of type for `null` literals

### DIFF
--- a/Rewrite/src/Rewrite.CSharp/Parser/CSharpParserVisitor.cs
+++ b/Rewrite/src/Rewrite.CSharp/Parser/CSharpParserVisitor.cs
@@ -3603,6 +3603,10 @@ public class CSharpParserVisitor(CSharpParser parser, SemanticModel semanticMode
 
     private JavaType MapType(ExpressionSyntax ins)
     {
+        if (ins.IsKind(SyntaxKind.NullLiteralExpression))
+        {
+            return new JavaType.Primitive(JavaType.Primitive.PrimitiveType.Null);
+        }
         return _typeMapping.Type(semanticModel.GetTypeInfo(ins).Type);
     }
 

--- a/Rewrite/tests/Rewrite.CSharp.Tests/Tree/LiteralTests.cs
+++ b/Rewrite/tests/Rewrite.CSharp.Tests/Tree/LiteralTests.cs
@@ -1,4 +1,6 @@
+using FluentAssertions;
 using Rewrite.RewriteCSharp.Test.Api;
+using Rewrite.RewriteJava.Tree;
 using Rewrite.Test;
 
 namespace Rewrite.CSharp.Tests.Tree;
@@ -61,6 +63,29 @@ public class LiteralTests : RewriteTest
                     nuint _nui = 1;
                 }
                 """
+            )
+        );
+    }
+
+    [Fact]
+    private void Null()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                public class T
+                {
+                    object _o = null;
+                }
+                """,
+                spec: spec => spec.AfterRecipe = cu =>
+                {
+                    var o = (J.VariableDeclarations)((J.ClassDeclaration)cu.Members[0]).Body.Statements[0];
+                    o.Should().NotBeNull();
+                    var nullLiteral = (J.Literal)o.Variables[0].Initializer!;
+                    nullLiteral.Type.Should().BeOfType<JavaType.Primitive>();
+                    nullLiteral.Type.Kind.Should().Be(JavaType.Primitive.PrimitiveType.Null);
+                }
             )
         );
     }


### PR DESCRIPTION
The `TypeInfo` for a `null` literal is expected to have a `null` `Type` property value.
