### PR TITLE
Adding the dependencycheck plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("org.openrewrite.build.root") version("latest.release")
     id("org.openrewrite.build.java-base") version("latest.release")
+    id("org.owasp.dependencycheck") version "latest.release"
 }
 
 allprojects {


### PR DESCRIPTION
The vulnerability-analysis github action is failing to run because this repository doesn't have the `dependencyCheckAggregate` task. This task is provided by the `org.owasp.dependencycheck` gradle plugin


Github action output: https://github.com/moderneinc/dependency-vulnerability-reports/actions/runs/12570425807/job/35040333841#step:7:1
